### PR TITLE
add irishub v2.1 upgrade docs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.idea/
+.vscode/

--- a/upgrade/v2.1.0.md
+++ b/upgrade/v2.1.0.md
@@ -5,8 +5,8 @@
 We are prepared to upgrade the IRIS Hub based upon
 
 - Version: `v2.1.0`
-- Commit hash: `a2ac8c2709f43e33e782989754b92db65332c879`;
-- Chain Halt at Block Height: ``;
+- Commit hash: `39fdf6c85a5fca711e2aa7282f574a7f365c875e`;
+- Chain Halt at Block Height: `23169564`;
 
 ## Upgrade Process
 
@@ -35,7 +35,7 @@ iris version --long
 name: iris
 server_name: iris
 version: v2.1.0
-commit: a2ac8c2709f43e33e782989754b92db65332c879
+commit: 39fdf6c85a5fca711e2aa7282f574a7f365c875e
 build_tags: netgo,ledger
 go: go version go1.19 darwin/amd64
 

--- a/upgrade/v2.1.0.md
+++ b/upgrade/v2.1.0.md
@@ -1,0 +1,51 @@
+# IRIS Hub Upgrade v2.1.0
+
+## Upgrade Proposal
+
+We are prepared to upgrade the IRIS Hub based upon
+
+- Version: `v2.1.0`
+- Commit hash: `a2ac8c2709f43e33e782989754b92db65332c879`;
+- Chain Halt at Block Height: ``;
+
+## Upgrade Process
+
+### 1. Vote
+
+```bash
+iris tx gov vote <proposal-id> <yes|no|no_with_veto|abstain> --chain-id irishub-1 --fees 0.3iris --from <MyWallet>
+```
+
+### 2. Upgrade Nodes
+
+If the **Upgrade Proposal** successfully passes, the IRIS Hub will be halted automatically at around UTC `2024-01-08 05:30:00Z`, so we can upgrade all the irishub nodes right away.
+
+**Note: All nodes have to be upgraded, whether it is a validator node, a seed node or a full node.**
+
+The specific steps are as follows:
+
+```bash
+# 1. Compile and install the new version, go 1.19+ is required
+git clone https://github.com/irisnet/irishub
+cd irishub && git checkout v2.1.0
+make install
+
+# 2. Check the version number
+iris version --long
+name: iris
+server_name: iris
+version: v2.1.0
+commit: a2ac8c2709f43e33e782989754b92db65332c879
+build_tags: netgo,ledger
+go: go version go1.19 darwin/amd64
+
+# 3. Close the old software
+kill -9 <iris-pid>
+
+# 4. Restart
+iris start --home=<path-to-your-home>
+```
+
+### 3. Wait for Blocks
+
+When the voting power of validators that have completed the upgrade exceeds 67%, irishub can resume producing blocks, and the upgrade is completed.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Implemented a `.gitignore` file to exclude specific directories from version control.

- **Documentation**
  - Published an upgrade guide for transitioning to IRIS Hub version v2.1.0, detailing the steps for voting, halting, upgrading, and resuming block production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->