### PR TITLE
update v2.1 upgrade docs

### DIFF
--- a/upgrade/v2.1.0.md
+++ b/upgrade/v2.1.0.md
@@ -6,7 +6,7 @@ We are prepared to upgrade the IRIS Hub based upon
 
 - Version: `v2.1.0`
 - Commit hash: `39fdf6c85a5fca711e2aa7282f574a7f365c875e`;
-- Chain Halt at Block Height: `23169564`;
+- Chain Halt at Block Height: `23170081`;
 
 ## Upgrade Process
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "Chain Halt at Block Height" value in the upgrade guide for version 2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->